### PR TITLE
restore .tl-icon-image as per original Knightlab Timeline

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -83,7 +83,6 @@
     color: #000 !important;
   }
 
-  .tl-icon-image,
   .tl-slidenav-title,
   .tl-slidenav-description {
     display: none !important;


### PR DESCRIPTION
Not sure if this missing icon is intentional or an oversight. Making this PR just in case...