### PR TITLE
Make language choice more like standard H5P contents

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -300,35 +300,170 @@
       ]
     },
     {
-      "label": "Localize",
-      "fields": [
+      "label": "Language",
+      "description": "The language of the user interface",
+      "options": [
         {
-          "label": "Rights of use",
-          "default": "Rights of use"
+          "label": "Afrikaans"
         },
         {
-          "label": "Copyright - Title",
-          "default": "Title"
+          "label": "Arabic"
         },
         {
-          "label": "Copyright - Author",
-          "default": "Author"
+          "label": "Armenian"
         },
         {
-          "label": "Copyright - Year",
-          "default": "Year"
+          "label": "Basque"
         },
         {
-          "label": "Copyright - Source",
-          "default": "Source"
+          "label": "Bulgarian"
         },
         {
-          "label": "Copyright - License",
-          "default": "License"
+          "label": "Catalan"
         },
         {
-          "label": "Copyright - Version",
-          "default": "Version"
+          "label": "Chinese"
+        },
+        {
+          "label": "Croatian / Hrvatski"
+        },
+        {
+          "label": "Czech"
+        },
+        {
+          "label": "Danish"
+        },
+        {
+          "label": "Dutch"
+        },
+        {
+          "label": "English"
+        },
+        {
+          "label": "English (24-hour time)"
+        },
+        {
+          "label": "Esperanto"
+        },
+        {
+          "label": "Estonian"
+        },
+        {
+          "label": "Faroese"
+        },
+        {
+          "label": "Farsi"
+        },
+        {
+          "label": "Finnish"
+        },
+        {
+          "label": "French"
+        },
+        {
+          "label": "Galician"
+        },
+        {
+          "label": "Georgian"
+        },
+        {
+          "label": "German / Deutsch"
+        },
+        {
+          "label": "Greek"
+        },
+        {
+          "label": "Hebrew"
+        },
+        {
+          "label": "Hungarian"
+        },
+        {
+          "label": "Icelandic"
+        },
+        {
+          "label": "Indonesian"
+        },
+        {
+          "label": "Italian"
+        },
+        {
+          "label": "Japanese"
+        },
+        {
+          "label": "Korean"
+        },
+        {
+          "label": "Latvian"
+        },
+        {
+          "label": "Lithuanian"
+        },
+        {
+          "label": "Luxembourgish"
+        },
+        {
+          "label": "Malay"
+        },
+        {
+          "label": "Nepali"
+        },
+        {
+          "label": "Norwegian"
+        },
+        {
+          "label": "Polish"
+        },
+        {
+          "label": "Portuguese"
+        },
+        {
+          "label": "Portuguese (Brazilian)"
+        },
+        {
+          "label": "Romansh"
+        },
+        {
+          "label": "Russian"
+        },
+        {
+          "label": "Serbian - Cyrillic"
+        },
+        {
+          "label": "Serbian - Latin"
+        },
+        {
+          "label": "Sinhalese"
+        },
+        {
+          "label": "Slovak"
+        },
+        {
+          "label": "Slovenian"
+        },
+        {
+          "label": "Spanish"
+        },
+        {
+          "label": "Swedish"
+        },
+        {
+          "label": "Tagalog"
+        },
+        {
+          "label": "Tamil"
+        },
+        {
+          "label": "Taiwanese"
+        },
+        {
+          "label": "Telugu"
+        },
+        {
+          "label": "Turkish"
+        },
+        {
+          "label": "Ukrainian"
         }
       ]
     }

--- a/language/de.json
+++ b/language/de.json
@@ -300,35 +300,170 @@
       ]
     },
     {
-      "label": "Localize",
-      "fields": [
+      "label": "Sprache",
+      "description": "Die Sprache der Benutzeroberfläche",
+      "options": [
         {
-          "label": "Rights of use",
-          "default": "Rights of use"
+          "label": "Afrikaans"
         },
         {
-          "label": "Copyright - Title",
-          "default": "Title"
+          "label": "Arabisch"
         },
         {
-          "label": "Copyright - Author",
-          "default": "Author"
+          "label": "Armenisch"
         },
         {
-          "label": "Copyright - Year",
-          "default": "Year"
+          "label": "Baskisch"
         },
         {
-          "label": "Copyright - Source",
-          "default": "Source"
+          "label": "Bulgarisch"
         },
         {
-          "label": "Copyright - License",
-          "default": "License"
+          "label": "Katalanisch"
         },
         {
-          "label": "Copyright - Version",
-          "default": "Version"
+          "label": "Chinesisch"
+        },
+        {
+          "label": "Kroatisch"
+        },
+        {
+          "label": "Tschechisch"
+        },
+        {
+          "label": "Dänisch"
+        },
+        {
+          "label": "Niederländisch"
+        },
+        {
+          "label": "Englisch"
+        },
+        {
+          "label": "Englisch (24-Stunden-Zeitformat)"
+        },
+        {
+          "label": "Esperanto"
+        },
+        {
+          "label": "Estnisch"
+        },
+        {
+          "label": "Färöisch"
+        },
+        {
+          "label": "Farsi"
+        },
+        {
+          "label": "Finnisch"
+        },
+        {
+          "label": "Französisch"
+        },
+        {
+          "label": "Galicisch"
+        },
+        {
+          "label": "Georgisch"
+        },
+        {
+          "label": "Deutsch"
+        },
+        {
+          "label": "Griechisch"
+        },
+        {
+          "label": "Hebräisch"
+        },
+        {
+          "label": "Ungarisch"
+        },
+        {
+          "label": "Isländisch"
+        },
+        {
+          "label": "Indonesisch"
+        },
+        {
+          "label": "Italienisch"
+        },
+        {
+          "label": "Japanisch"
+        },
+        {
+          "label": "Koreanisch"
+        },
+        {
+          "label": "Lettisch"
+        },
+        {
+          "label": "Litauisch"
+        },
+        {
+          "label": "Luxembourgisch"
+        },
+        {
+          "label": "Malayisch"
+        },
+        {
+          "label": "Nepalesisch"
+        },
+        {
+          "label": "Norwegisch"
+        },
+        {
+          "label": "Polnisch"
+        },
+        {
+          "label": "Portugiesisch"
+        },
+        {
+          "label": "Portugiesisch (Brasilien)"
+        },
+        {
+          "label": "Rumänisch"
+        },
+        {
+          "label": "Russisch"
+        },
+        {
+          "label": "Serbisch - kyrillische Schrift"
+        },
+        {
+          "label": "Serbisch - lateinische Schrift"
+        },
+        {
+          "label": "Singhalesisch"
+        },
+        {
+          "label": "Slowakisch"
+        },
+        {
+          "label": "Slowenisch"
+        },
+        {
+          "label": "Spanisch"
+        },
+        {
+          "label": "Schwedisch"
+        },
+        {
+          "label": "Tagalog"
+        },
+        {
+          "label": "Tamil"
+        },
+        {
+          "label": "Taiwanesisch"
+        },
+        {
+          "label": "Telugu"
+        },
+        {
+          "label": "Türkisch"
+        },
+        {
+          "label": "Ukrainisch"
         }
       ]
     }

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -301,34 +301,169 @@
     },
     {
       "label": "Adaptación local",
-      "fields": [
+      "description": "The language of the user interface",
+      "options": [
         {
-          "label": "Derechos de uso",
-          "default": "Derechos de uso"
+          "label": "Afrikaans"
         },
         {
-          "label": "Copyright - Título",
-          "default": "Título"
+          "label": "Arabic"
         },
         {
-          "label": "Copyright - Autor",
-          "default": "Autor"
+          "label": "Armenian"
         },
         {
-          "label": "Copyright - Año",
-          "default": "Año"
+          "label": "Basque"
         },
         {
-          "label": "Copyright - Origen",
-          "default": "Origen"
+          "label": "Bulgarian"
         },
         {
-          "label": "Copyright - Licencia",
-          "default": "Licencia"
+          "label": "Catalan"
         },
         {
-          "label": "Copyright - Versión",
-          "default": "Versión"
+          "label": "Chinese"
+        },
+        {
+          "label": "Croatian / Hrvatski"
+        },
+        {
+          "label": "Czech"
+        },
+        {
+          "label": "Danish"
+        },
+        {
+          "label": "Dutch"
+        },
+        {
+          "label": "English"
+        },
+        {
+          "label": "English (24-hour time)"
+        },
+        {
+          "label": "Esperanto"
+        },
+        {
+          "label": "Estonian"
+        },
+        {
+          "label": "Faroese"
+        },
+        {
+          "label": "Farsi"
+        },
+        {
+          "label": "Finnish"
+        },
+        {
+          "label": "French"
+        },
+        {
+          "label": "Galician"
+        },
+        {
+          "label": "Georgian"
+        },
+        {
+          "label": "German / Deutsch"
+        },
+        {
+          "label": "Greek"
+        },
+        {
+          "label": "Hebrew"
+        },
+        {
+          "label": "Hungarian"
+        },
+        {
+          "label": "Icelandic"
+        },
+        {
+          "label": "Indonesian"
+        },
+        {
+          "label": "Italian"
+        },
+        {
+          "label": "Japanese"
+        },
+        {
+          "label": "Korean"
+        },
+        {
+          "label": "Latvian"
+        },
+        {
+          "label": "Lithuanian"
+        },
+        {
+          "label": "Luxembourgish"
+        },
+        {
+          "label": "Malay"
+        },
+        {
+          "label": "Nepali"
+        },
+        {
+          "label": "Norwegian"
+        },
+        {
+          "label": "Polish"
+        },
+        {
+          "label": "Portuguese"
+        },
+        {
+          "label": "Portuguese (Brazilian)"
+        },
+        {
+          "label": "Romansh"
+        },
+        {
+          "label": "Russian"
+        },
+        {
+          "label": "Serbian - Cyrillic"
+        },
+        {
+          "label": "Serbian - Latin"
+        },
+        {
+          "label": "Sinhalese"
+        },
+        {
+          "label": "Slovak"
+        },
+        {
+          "label": "Slovenian"
+        },
+        {
+          "label": "Spanish"
+        },
+        {
+          "label": "Swedish"
+        },
+        {
+          "label": "Tagalog"
+        },
+        {
+          "label": "Tamil"
+        },
+        {
+          "label": "Taiwanese"
+        },
+        {
+          "label": "Telugu"
+        },
+        {
+          "label": "Turkish"
+        },
+        {
+          "label": "Ukrainian"
         }
       ]
     }

--- a/language/es.json
+++ b/language/es.json
@@ -300,35 +300,170 @@
       ]
     },
     {
-      "label": "Localizar",
-      "fields": [
+      "label": "Idioma",
+      "description": "Idioma de la interfaz de usuario",
+      "options": [
         {
-          "label": "Derechos de uso",
-          "default": "Derechos de uso"
+          "label": "Afrikaans"
         },
         {
-          "label": "Copyright - Título",
-          "default": "Título"
+          "label": "Árabe"
         },
         {
-          "label": "Copyright - Autor",
-          "default": "Autor"
+          "label": "Armenio"
         },
         {
-          "label": "Copyright - Año",
-          "default": "Año"
+          "label": "Vasco"
         },
         {
-          "label": "Copyright - Origen",
-          "default": "Origen"
+          "label": "Búlgaro"
         },
         {
-          "label": "Copyright - Licencia",
-          "default": "Licencia"
+          "label": "Catalán"
         },
         {
-          "label": "Copyright - Versión",
-          "default": "Versión"
+          "label": "Chino"
+        },
+        {
+          "label": "Croata / Hrvatski"
+        },
+        {
+          "label": "Checo"
+        },
+        {
+          "label": "Danés"
+        },
+        {
+          "label": "Holandés"
+        },
+        {
+          "label": "Inglés"
+        },
+        {
+          "label": "Inglés (horario de 24-horas)"
+        },
+        {
+          "label": "Esperanto"
+        },
+        {
+          "label": "Estonio"
+        },
+        {
+          "label": "Feroés"
+        },
+        {
+          "label": "Persa"
+        },
+        {
+          "label": "Finlandés"
+        },
+        {
+          "label": "Francés"
+        },
+        {
+          "label": "Gallego"
+        },
+        {
+          "label": "Georgiano"
+        },
+        {
+          "label": "Alemán / Deutsch"
+        },
+        {
+          "label": "Griego"
+        },
+        {
+          "label": "Hebreo"
+        },
+        {
+          "label": "Húngaro"
+        },
+        {
+          "label": "Islandés"
+        },
+        {
+          "label": "Indonesio"
+        },
+        {
+          "label": "Italiano"
+        },
+        {
+          "label": "Japonés"
+        },
+        {
+          "label": "Coreano"
+        },
+        {
+          "label": "Latvio"
+        },
+        {
+          "label": "Lituano"
+        },
+        {
+          "label": "Luxemburgués"
+        },
+        {
+          "label": "Malayo"
+        },
+        {
+          "label": "Nepalí"
+        },
+        {
+          "label": "Noruego"
+        },
+        {
+          "label": "Polaco"
+        },
+        {
+          "label": "Portugués"
+        },
+        {
+          "label": "Portugués (Brasileño)"
+        },
+        {
+          "label": "Rumano"
+        },
+        {
+          "label": "Ruso"
+        },
+        {
+          "label": "Serbio - Cirílico"
+        },
+        {
+          "label": "Serbio - Latino"
+        },
+        {
+          "label": "Sinhalés"
+        },
+        {
+          "label": "Eslovaco"
+        },
+        {
+          "label": "Esloveno"
+        },
+        {
+          "label": "Español"
+        },
+        {
+          "label": "Sueco"
+        },
+        {
+          "label": "Tagalo"
+        },
+        {
+          "label": "Tamil"
+        },
+        {
+          "label": "Taiwanés"
+        },
+        {
+          "label": "Télugu"
+        },
+        {
+          "label": "Turco"
+        },
+        {
+          "label": "Ucraniano"
         }
       ]
     }

--- a/language/eu.json
+++ b/language/eu.json
@@ -300,35 +300,170 @@
       ]
     },
     {
-      "label": "Localize",
-      "fields": [
+      "label": "Hizkuntza",
+      "description": "Erabiltzailearen interfazearen hizkuntza",
+      "options": [
         {
-          "label": "Rights of use",
-          "default": "Rights of use"
+          "label": "Afrikaans"
         },
         {
-          "label": "Copyright - Title",
-          "default": "Title"
+          "label": "Arabiera"
         },
         {
-          "label": "Copyright - Author",
-          "default": "Author"
+          "label": "Armeniera"
         },
         {
-          "label": "Copyright - Year",
-          "default": "Year"
+          "label": "Euskara"
         },
         {
-          "label": "Copyright - Source",
-          "default": "Source"
+          "label": "Bulgariera"
         },
         {
-          "label": "Copyright - License",
-          "default": "License"
+          "label": "Katalana"
         },
         {
-          "label": "Copyright - Version",
-          "default": "Version"
+          "label": "Txinera"
+        },
+        {
+          "label": "Kroaziera"
+        },
+        {
+          "label": "Txekiera"
+        },
+        {
+          "label": "Daniera"
+        },
+        {
+          "label": "Nederlandera"
+        },
+        {
+          "label": "Ingelesa"
+        },
+        {
+          "label": "Ingelesa (24 orduko denbora)"
+        },
+        {
+          "label": "Esperanto"
+        },
+        {
+          "label": "Estoniera"
+        },
+        {
+          "label": "Faroera"
+        },
+        {
+          "label": "Persiera"
+        },
+        {
+          "label": "Suomiera"
+        },
+        {
+          "label": "Frantsesa"
+        },
+        {
+          "label": "Galego"
+        },
+        {
+          "label": "Georgiera"
+        },
+        {
+          "label": "Alemana"
+        },
+        {
+          "label": "Grekera"
+        },
+        {
+          "label": "Hebraiera"
+        },
+        {
+          "label": "Hungariera"
+        },
+        {
+          "label": "Islandiera"
+        },
+        {
+          "label": "Indonesiera"
+        },
+        {
+          "label": "Italiera"
+        },
+        {
+          "label": "Japoniera"
+        },
+        {
+          "label": "Koreera"
+        },
+        {
+          "label": "Letoniera"
+        },
+        {
+          "label": "Lituaniera"
+        },
+        {
+          "label": "Luxemburgera"
+        },
+        {
+          "label": "Malayera"
+        },
+        {
+          "label": "Nepalera"
+        },
+        {
+          "label": "Norvegiera"
+        },
+        {
+          "label": "Poloniera"
+        },
+        {
+          "label": "Portugesa"
+        },
+        {
+          "label": "Portugesa (Brasiliera)"
+        },
+        {
+          "label": "Erromantxera"
+        },
+        {
+          "label": "Errusiera"
+        },
+        {
+          "label": "Serbiera - Zirilikoa"
+        },
+        {
+          "label": "Serbiera - Latino"
+        },
+        {
+          "label": "Sinhala"
+        },
+        {
+          "label": "Eslovakiera"
+        },
+        {
+          "label": "Esloveniera"
+        },
+        {
+          "label": "Gaztelera"
+        },
+        {
+          "label": "Suediera"
+        },
+        {
+          "label": "Etiketaaloa"
+        },
+        {
+          "label": "Tamilera"
+        },
+        {
+          "label": "Taiwanera"
+        },
+        {
+          "label": "Telugu"
+        },
+        {
+          "label": "Turkiera"
+        },
+        {
+          "label": "Ukrainera"
         }
       ]
     }

--- a/language/gl.json
+++ b/language/gl.json
@@ -299,38 +299,173 @@
         }
       ]
     },
-    {
-      "label": "Adaptación local",
-      "fields": [
         {
-          "label": "Dereitos de uso",
-          "default": "Dereitos de uso"
-        },
-        {
-          "label": "Copyright - Título",
-          "default": "Título"
-        },
-        {
-          "label": "Copyright - Autor",
-          "default": "Autor"
-        },
-        {
-          "label": "Copyright - Ano",
-          "default": "Ano"
-        },
-        {
-          "label": "Copyright - Fonte",
-          "default": "Fonte"
-        },
-        {
-          "label": "Copyright - Licenza",
-          "default": "Licenza"
-        },
-        {
-          "label": "Copyright - Versión",
-          "default": "Versión"
+          "label": "Idioma",
+          "description": "O idioma da interface de usuario",
+          "options": [
+            {
+              "label": "Afrikaans"
+            },
+            {
+              "label": "Árabe"
+            },
+            {
+              "label": "Armenio"
+            },
+            {
+              "label": "Vasco"
+            },
+            {
+              "label": "Búlgaro"
+            },
+            {
+              "label": "Catalán"
+            },
+            {
+              "label": "Chines"
+            },
+            {
+              "label": "Croata / Hrvatski"
+            },
+            {
+              "label": "Checo"
+            },
+            {
+              "label": "Danés"
+            },
+            {
+              "label": "Holandés"
+            },
+            {
+              "label": "Inglés"
+            },
+            {
+              "label": "Inglés (formato 24 horas)"
+            },
+            {
+              "label": "Esperanto"
+            },
+            {
+              "label": "Estonio"
+            },
+            {
+              "label": "Faroes"
+            },
+            {
+              "label": "Farsi"
+            },
+            {
+              "label": "Finlandés"
+            },
+            {
+              "label": "Francés"
+            },
+            {
+              "label": "Galego"
+            },
+            {
+              "label": "Georgiano"
+            },
+            {
+              "label": "Alemán / Deutsch"
+            },
+            {
+              "label": "Grego"
+            },
+            {
+              "label": "Hebreo"
+            },
+            {
+              "label": "Húngaro"
+            },
+            {
+              "label": "Islandés"
+            },
+            {
+              "label": "Indonesio"
+            },
+            {
+              "label": "Italiano"
+            },
+            {
+              "label": "Xaponés"
+            },
+            {
+              "label": "Koreano"
+            },
+            {
+              "label": "Latvio"
+            },
+            {
+              "label": "Lituano"
+            },
+            {
+              "label": "Luxemburgués"
+            },
+            {
+              "label": "Malaio"
+            },
+            {
+              "label": "Nepalés"
+            },
+            {
+              "label": "Noruego"
+            },
+            {
+              "label": "Polaco"
+            },
+            {
+              "label": "Portugués"
+            },
+            {
+              "label": "Portugués (Brasileiro)"
+            },
+            {
+              "label": "Romanés"
+            },
+            {
+              "label": "Ruso"
+            },
+            {
+              "label": "Serbio - Cirílico"
+            },
+            {
+              "label": "Serbio - Latín"
+            },
+            {
+              "label": "Cingalés"
+            },
+            {
+              "label": "Eslovaco"
+            },
+            {
+              "label": "Sloveno"
+            },
+            {
+              "label": "Español"
+            },
+            {
+              "label": "Sueco"
+            },
+            {
+              "label": "Tagalo"
+            },
+            {
+              "label": "Tamil"
+            },
+            {
+              "label": "Taiwanes"
+            },
+            {
+              "label": "Telugu"
+            },
+            {
+              "label": "Turco"
+            },
+            {
+              "label": "Ukraniano"
+            }
+          ]
         }
-      ]
-    }
   ]
 }

--- a/language/nb.json
+++ b/language/nb.json
@@ -300,35 +300,170 @@
       ]
     },
     {
-      "label": "Oversett",
-      "fields": [
+      "label": "Språk",
+      "description": "Språk for grensesnittet",
+      "options": [
         {
-          "label": "Bruksrett",
-          "default": "Bruksrett"
+          "label": "Afrikaans"
         },
         {
-          "label": "Bruksrettigheter - Tittel",
-          "default": "Tittel"
+          "label": "Arabic"
         },
         {
-          "label": "Bruksrettigheter - Forfatter",
-          "default": "Forfatter"
+          "label": "Armenian"
         },
         {
-          "label": "Bruksrettigheter - År",
-          "default": "År"
+          "label": "Basque"
         },
         {
-          "label": "Bruksrettigheter - Kilde",
-          "default": "Kilde"
+          "label": "Bulgarian"
         },
         {
-          "label": "Bruksrettigheter - Lisens",
-          "default": "Lisens"
+          "label": "Catalan"
         },
         {
-          "label": "Bruksrettigheter - Versjon",
-          "default": "Versjon"
+          "label": "Chinese"
+        },
+        {
+          "label": "Croatian / Hrvatski"
+        },
+        {
+          "label": "Czech"
+        },
+        {
+          "label": "Danish"
+        },
+        {
+          "label": "Dutch"
+        },
+        {
+          "label": "English"
+        },
+        {
+          "label": "English (24-hour time)"
+        },
+        {
+          "label": "Esperanto"
+        },
+        {
+          "label": "Estonian"
+        },
+        {
+          "label": "Faroese"
+        },
+        {
+          "label": "Farsi"
+        },
+        {
+          "label": "Finnish"
+        },
+        {
+          "label": "French"
+        },
+        {
+          "label": "Galician"
+        },
+        {
+          "label": "Georgian"
+        },
+        {
+          "label": "German / Deutsch"
+        },
+        {
+          "label": "Greek"
+        },
+        {
+          "label": "Hebrew"
+        },
+        {
+          "label": "Hungarian"
+        },
+        {
+          "label": "Icelandic"
+        },
+        {
+          "label": "Indonesian"
+        },
+        {
+          "label": "Italian"
+        },
+        {
+          "label": "Japanese"
+        },
+        {
+          "label": "Korean"
+        },
+        {
+          "label": "Latvian"
+        },
+        {
+          "label": "Lithuanian"
+        },
+        {
+          "label": "Luxembourgish"
+        },
+        {
+          "label": "Malay"
+        },
+        {
+          "label": "Nepali"
+        },
+        {
+          "label": "Norwegian"
+        },
+        {
+          "label": "Polish"
+        },
+        {
+          "label": "Portuguese"
+        },
+        {
+          "label": "Portuguese (Brazilian)"
+        },
+        {
+          "label": "Romansh"
+        },
+        {
+          "label": "Russian"
+        },
+        {
+          "label": "Serbian - Cyrillic"
+        },
+        {
+          "label": "Serbian - Latin"
+        },
+        {
+          "label": "Sinhalese"
+        },
+        {
+          "label": "Slovak"
+        },
+        {
+          "label": "Slovenian"
+        },
+        {
+          "label": "Spanish"
+        },
+        {
+          "label": "Swedish"
+        },
+        {
+          "label": "Tagalog"
+        },
+        {
+          "label": "Tamil"
+        },
+        {
+          "label": "Taiwanese"
+        },
+        {
+          "label": "Telugu"
+        },
+        {
+          "label": "Turkish"
+        },
+        {
+          "label": "Ukrainian"
         }
       ]
     }

--- a/language/nn.json
+++ b/language/nn.json
@@ -301,34 +301,169 @@
     },
     {
       "label": "Oversett",
-      "fields": [
+      "description": "The language of the user interface",
+      "options": [
         {
-          "label": "Bruksrettar",
-          "default": "Bruksrettar"
+          "label": "Afrikaans"
         },
         {
-          "label": "Bruksrettar - Tittel",
-          "default": "Tittel"
+          "label": "Arabic"
         },
         {
-          "label": "Bruksrettar - Forfatter",
-          "default": "Forfatter"
+          "label": "Armenian"
         },
         {
-          "label": "Bruksrettar - År",
-          "default": "År"
+          "label": "Basque"
         },
         {
-          "label": "Bruksrettar - Kjelde",
-          "default": "Kjelde"
+          "label": "Bulgarian"
         },
         {
-          "label": "Bruksrettar - Lisens",
-          "default": "Lisens"
+          "label": "Catalan"
         },
         {
-          "label": "Bruksrettar - Versjon",
-          "default": "Versjon"
+          "label": "Chinese"
+        },
+        {
+          "label": "Croatian / Hrvatski"
+        },
+        {
+          "label": "Czech"
+        },
+        {
+          "label": "Danish"
+        },
+        {
+          "label": "Dutch"
+        },
+        {
+          "label": "English"
+        },
+        {
+          "label": "English (24-hour time)"
+        },
+        {
+          "label": "Esperanto"
+        },
+        {
+          "label": "Estonian"
+        },
+        {
+          "label": "Faroese"
+        },
+        {
+          "label": "Farsi"
+        },
+        {
+          "label": "Finnish"
+        },
+        {
+          "label": "French"
+        },
+        {
+          "label": "Galician"
+        },
+        {
+          "label": "Georgian"
+        },
+        {
+          "label": "German / Deutsch"
+        },
+        {
+          "label": "Greek"
+        },
+        {
+          "label": "Hebrew"
+        },
+        {
+          "label": "Hungarian"
+        },
+        {
+          "label": "Icelandic"
+        },
+        {
+          "label": "Indonesian"
+        },
+        {
+          "label": "Italian"
+        },
+        {
+          "label": "Japanese"
+        },
+        {
+          "label": "Korean"
+        },
+        {
+          "label": "Latvian"
+        },
+        {
+          "label": "Lithuanian"
+        },
+        {
+          "label": "Luxembourgish"
+        },
+        {
+          "label": "Malay"
+        },
+        {
+          "label": "Nepali"
+        },
+        {
+          "label": "Norwegian"
+        },
+        {
+          "label": "Polish"
+        },
+        {
+          "label": "Portuguese"
+        },
+        {
+          "label": "Portuguese (Brazilian)"
+        },
+        {
+          "label": "Romansh"
+        },
+        {
+          "label": "Russian"
+        },
+        {
+          "label": "Serbian - Cyrillic"
+        },
+        {
+          "label": "Serbian - Latin"
+        },
+        {
+          "label": "Sinhalese"
+        },
+        {
+          "label": "Slovak"
+        },
+        {
+          "label": "Slovenian"
+        },
+        {
+          "label": "Spanish"
+        },
+        {
+          "label": "Swedish"
+        },
+        {
+          "label": "Tagalog"
+        },
+        {
+          "label": "Tamil"
+        },
+        {
+          "label": "Taiwanese"
+        },
+        {
+          "label": "Telugu"
+        },
+        {
+          "label": "Turkish"
+        },
+        {
+          "label": "Ukrainian"
         }
       ]
     }

--- a/semantics.json
+++ b/semantics.json
@@ -806,53 +806,230 @@
     ]
   },
   {
-    "name": "l10n",
-    "type": "group",
-    "common": true,
-    "label": "Localize",
-    "fields": [
+    "name": "language",
+    "type": "select",
+    "label": "Language",
+    "importance": "medium",
+    "optional": true,
+    "description": "The language of the user interface",
+    "options": [
       {
-        "label": "Rights of use",
-        "name": "copyrightLabel",
-        "default": "Rights of use",
-        "type": "text"
+        "value": "af",
+        "label": "Afrikaans"
       },
       {
-        "label": "Copyright - Title",
-        "name": "copyrightTitle",
-        "default": "Title",
-        "type": "text"
+        "value": "ar",
+        "label": "Arabic"
       },
       {
-        "label": "Copyright - Author",
-        "name": "copyrightAuthor",
-        "default": "Author",
-        "type": "text"
+        "value": "hy",
+        "label": "Armenian"
       },
       {
-        "label": "Copyright - Year",
-        "name": "copyrightYear",
-        "default": "Year",
-        "type": "text"
+        "value": "eu",
+        "label": "Basque"
       },
       {
-        "label": "Copyright - Source",
-        "name": "copyrightSource",
-        "default": "Source",
-        "type": "text"
+        "value": "bg",
+        "label": "Bulgarian"
       },
       {
-        "label": "Copyright - License",
-        "name": "copyrightLicense",
-        "default": "License",
-        "type": "text"
+        "value": "ca",
+        "label": "Catalan"
       },
       {
-        "label": "Copyright - Version",
-        "name": "copyrightVersion",
-        "default": "Version",
-        "type": "text"
+        "value": "zh-cn",
+        "label": "Chinese"
+      },
+      {
+        "value": "hr",
+        "label": "Croatian / Hrvatski"
+      },
+      {
+        "value": "cz",
+        "label": "Czech"
+      },
+      {
+        "value": "da",
+        "label": "Danish"
+      },
+      {
+        "value": "nl",
+        "label": "Dutch"
+      },
+      {
+        "value": "en",
+        "label": "English"
+      },
+      {
+        "value": "en-24hr",
+        "label": "English (24-hour time)"
+      },
+      {
+        "value": "eo",
+        "label": "Esperanto"
+      },
+      {
+        "value": "et",
+        "label": "Estonian"
+      },
+      {
+        "value": "fo",
+        "label": "Faroese"
+      },
+      {
+        "value": "fa",
+        "label": "Farsi"
+      },
+      {
+        "value": "fi",
+        "label": "Finnish"
+      },
+      {
+        "value": "fr",
+        "label": "French"
+      },
+      {
+        "value": "gl",
+        "label": "Galician"
+      },
+      {
+        "value": "ka",
+        "label": "Georgian"
+      },
+      {
+        "value": "de",
+        "label": "German / Deutsch"
+      },
+      {
+        "value": "el",
+        "label": "Greek"
+      },
+      {
+        "value": "he",
+        "label": "Hebrew"
+      },
+      {
+        "value": "hu",
+        "label": "Hungarian"
+      },
+      {
+        "value": "is",
+        "label": "Icelandic"
+      },
+      {
+        "value": "id",
+        "label": "Indonesian"
+      },
+      {
+        "value": "it",
+        "label": "Italian"
+      },
+      {
+        "value": "ja",
+        "label": "Japanese"
+      },
+      {
+        "value": "ko",
+        "label": "Korean"
+      },
+      {
+        "value": "lv",
+        "label": "Latvian"
+      },
+      {
+        "value": "lt",
+        "label": "Lithuanian"
+      },
+      {
+        "value": "lb",
+        "label": "Luxembourgish"
+      },
+      {
+        "value": "ms",
+        "label": "Malay"
+      },
+      {
+        "value": "ne",
+        "label": "Nepali"
+      },
+      {
+        "value": "no",
+        "label": "Norwegian"
+      },
+      {
+        "value": "pl",
+        "label": "Polish"
+      },
+      {
+        "value": "pt",
+        "label": "Portuguese"
+      },
+      {
+        "value": "pt-br",
+        "label": "Portuguese (Brazilian)"
+      },
+      {
+        "value": "rm",
+        "label": "Romansh"
+      },
+      {
+        "value": "ru",
+        "label": "Russian"
+      },
+      {
+        "value": "sr-cy",
+        "label": "Serbian - Cyrillic"
+      },
+      {
+        "value": "sr",
+        "label": "Serbian - Latin"
+      },
+      {
+        "value": "si",
+        "label": "Sinhalese"
+      },
+      {
+        "value": "sk",
+        "label": "Slovak"
+      },
+      {
+        "value": "sl",
+        "label": "Slovenian"
+      },
+      {
+        "value": "es",
+        "label": "Spanish"
+      },
+      {
+        "value": "sv",
+        "label": "Swedish"
+      },
+      {
+        "value": "tl",
+        "label": "Tagalog"
+      },
+      {
+        "value": "ta",
+        "label": "Tamil"
+      },
+      {
+        "value": "zh-tw",
+        "label": "Taiwanese"
+      },
+      {
+        "value": "te",
+        "label": "Telugu"
+      },
+      {
+        "value": "tr",
+        "label": "Turkish"
+      },
+      {
+        "value": "uk",
+        "label": "Ukrainian"
       }
-    ]
+    ],
+    "default": "en"
   }
 ]

--- a/src/components/TimeLine/TimeLine.tsx
+++ b/src/components/TimeLine/TimeLine.tsx
@@ -48,7 +48,7 @@ export const TimeLine: React.FC<TimeLineProps> = ({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const containerId = `timeline-embed-${H5P.createUUID()}`;
-
+  const language: string = data.language as string;
   const aspectRatio = 16 / 9;
 
   const h5pMediaInstances: { [index: string]: IH5PContentType | null } = {};
@@ -94,7 +94,7 @@ export const TimeLine: React.FC<TimeLineProps> = ({
   useEffectOnce(() => {
     // eslint-disable-next-line no-new
     const timeline = new Timeline(containerId, timelineDefinition, {
-      language: getClosestLocaleCode(containerRef.current),
+      language: language,
     });
 
     const timelineContainer = containerRef.current?.querySelector(

--- a/src/types/Params.ts
+++ b/src/types/Params.ts
@@ -7,4 +7,5 @@ export type Params = TimelineData & {
   };
 
   l10n?: Translations;
+  language?: string;
 };


### PR DESCRIPTION
Currently in NDLA Timeline the language of the interface for the end-user is automatically determined by the current end-user's current language e.g. in Drupal. This feature determines the correct display of dates in various languages.
There are some issues with this method:
a) it works in Drupal, but does not work in Wordpress (not yet tested in Moodle);
b) a Timeline can be created with items in a different language from the end-user's current language, which means that the interface language will not match;
c) the language determination does not follow the standard H5P method, where language choice is an option in the editor parameters, as e.g. in the H5P Timeline content.
My PR provides a standard H5P language choice for the content creator, based on the H5P Timeline content.
Since the NDLA Copyright field has been removed from semantics, there is now no need for the obsolete Copyright language strings, which I have removed from semantics.
In the various NDLA Timeline language files I have added and copied the lists from the language files of the H5P Timeline content wherever possible.