### PR TITLE
ci(check-version): run on `pull_request_target`

### DIFF
--- a/.github/workflows/check-library-version.yml
+++ b/.github/workflows/check-library-version.yml
@@ -1,7 +1,7 @@
 name: Check H5P library version
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened # PR opens
       - labeled # PR is labeled
@@ -16,4 +16,4 @@ jobs:
 
     steps:
       - name: Check library version
-        uses: boyum/comment-h5p-library-version-action@v2.1 # https://github.com/boyum/comment-h5p-library-version-action
+        uses: boyum/comment-h5p-library-version-action@v2.3 # https://github.com/boyum/comment-h5p-library-version-action


### PR DESCRIPTION
This should allow for the workflow to be run from forks.