### PR TITLE
Fix button contrast when using keyboard

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -142,6 +142,13 @@
   }
 }
 
+.h5p-frame:not(.using-mouse) {
+  .h5p-timeline .tl-menubar-button:not(:disabled) {
+    &:focus {
+      color: #fff;
+    }
+  }
+}
 
 /* Local duplicate of default stylesheet by Knightlab, but not using external resources */
 @font-face {


### PR DESCRIPTION
When merged in, will fix the button contrast when using the keyboard.

Chromatic deployment fails, but that's not related to the code.